### PR TITLE
Auto-register new devices on GPS update if not yet registered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ ENV/
 
 *.csv
 .vscode/
+conf/Car-Forwarders-Config.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "Robot-Calling-Sytem"]
 	path = call_a_robot/Robot-Calling-Sytem
 	url = https://github.com/Haydencoe/Robot-Calling-Sytem.git
+[submodule "CAR-Forwarders"]
+	path = CAR-Forwarders
+	url = https://github.com/LCAS/CAR-Forwarders.git

--- a/Dockerfile.forwarders
+++ b/Dockerfile.forwarders
@@ -1,0 +1,7 @@
+FROM python:3.9
+
+COPY CAR-Forwarders /CAR-Forwarders
+WORKDIR /CAR-Forwarders
+RUN pip install paho-mqtt==1.6.1 websocket-client==1.3.3 rel==0.4.7
+
+CMD ["python", "MtoW.py"]

--- a/call_a_robot/callarobot.py
+++ b/call_a_robot/callarobot.py
@@ -93,7 +93,7 @@ class CARState:
                     'row': row
                 })
         self.log_id += 1
-        if state == 'INIT' or state == 'INIT':
+        if state == 'INIT':
             self.log_uid[user] += 1
 
     def get_closest_node(self, user):
@@ -443,6 +443,13 @@ class CARProtocol(webnsock.JsonWSProtocol):
 
     def on_location_update(self, payload):
         info('GPS update: ' + str(payload))
+
+        if payload['user'] not in self.car_states.users:
+            # we got a GPS from somebody yet unknown
+            info('got GPS from unregistered user, so init them now.')
+            self.car_states.users[payload['user']] = payload['user']
+            self.update_state(payload['user'], 'INIT')
+
         self.car_states.gps[payload['user']] = {
             'latitude': payload['latitude'],
             'longitude': payload['longitude'],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
     build: .
     image: lcas.lincoln.ac.uk/lcas/car:latest
     restart: always
-    build: . 
     #command: ["env"]
     #command: ["python", "callarobot.py"]
     ports:
@@ -13,10 +12,44 @@ services:
       - 8128:8128
     environment:
       # We are tkaking the Google Maps API key form a .env file (or set it before docker-compose up)
+      PYTHONUNBUFFERED: 1
       GMAPS_API: ${GMAPS_API:-define_your_API_key_in_a_dot_env_file}
       CAR_ROWS: ${CAR_ROWS:-1 2 3 4 5 6 7 8 9 10 11 12}
       WEBSOCKET_URL: ${WEBSOCKET_URL:-wss://lcas.lincoln.ac.uk/rasberry/ws}
       CAR_LOG_DIR: "/car_logs"
     volumes:
       - ./logs:/car_logs
+
+  car_forwards_MtoW:
+    #depends_on:
+    #  - car
+    image: lcas.lincoln.ac.uk/lcas/car-forwarders:latest
+    restart: always
+    build: 
+      context: .
+      dockerfile: Dockerfile.forwarders 
+    volumes:
+      - ./conf/Car-Forwarders-Config.py:/CAR-Forwarders/Config.py:ro
+    environment:
+      # We are tkaking the Google Maps API key form a .env file (or set it before docker-compose up)
+      PYTHONUNBUFFERED: 1
+
+  car_forwards_WtoM:
+    #depends_on:
+    #  - car
+    image: lcas.lincoln.ac.uk/lcas/car-forwarders:latest
+    restart: always
+    build: 
+      context: .
+      dockerfile: Dockerfile.forwarders 
+    volumes:
+      - ./conf/Car-Forwarders-Config.py:/CAR-Forwarders/Config.py:ro
+    command: ["python", "WtoM.py"]
+    environment:
+      # We are tkaking the Google Maps API key form a .env file (or set it before docker-compose up)
+      PYTHONUNBUFFERED: 1
+      #GMAPS_API: ${GMAPS_API:-define_your_API_key_in_a_dot_env_file}
+      #CAR_ROWS: ${CAR_ROWS:-1 2 3 4 5 6 7 8 9 10 11 12}
+      #WEBSOCKET_URL: ${WEBSOCKET_URL:-wss://lcas.lincoln.ac.uk/car/ws}
+      #CAR_LOG_DIR: "/car_logs"
     


### PR DESCRIPTION
mostly changes that relate to the websocket<-> mqtt bridges, so won't affect anything. 

Only really change is that a new GPS position for a user that has not been received yet will automatically be registered (in CAR), to ensure a CAR restart can be done without restarting clients.

